### PR TITLE
Add try/except for 'N/A' value which cannot be converted to float.

### DIFF
--- a/load_nodes_slurm.py
+++ b/load_nodes_slurm.py
@@ -121,7 +121,10 @@ for node in param_nodes:
     cpu_load = node["CPULoad"]
     alloc = node["CPUAlloc"]
     ram_full = node["RealMemory"]
-    ram_free = node["FreeMem"]
+    try:
+        ram_free = float(node["FreeMem"])
+    except ValueError:
+        ram_free = 0.0
     ram_usage = (float(ram_full)-float(ram_free))/float(ram_full)
     """
     print(node["NodeName"], n_state, "   \t" + str(alloc) + "/" + str(ncpus),


### PR DESCRIPTION
Minor fix occuring when nodes in `DOWN` state would report `N/A` value of free RAM memory resulting in `ValueError` when converting to float.